### PR TITLE
Fix: Ordinary users unable to use WYSIWYG editor when Loop Post WYSIWYG module is enabled

### DIFF
--- a/modules/loop_post_wysiwyg/loop_post_wysiwyg.module
+++ b/modules/loop_post_wysiwyg/loop_post_wysiwyg.module
@@ -25,3 +25,36 @@ function loop_post_wysiwyg_form_node_form_alter(&$form, &$form_state) {
 function loop_post_wysiwyg_form_comment_form_alter(&$form) {
   $GLOBALS['use_wysiwyg_comments'] = $form['comment_body'][LANGUAGE_NONE][0]['#wysiwyg'] = TRUE;
 }
+
+/**
+ * Implements hook_enable().
+ */
+function loop_post_wysiwyg_enable() {
+  secure_permissions_rebuild();
+}
+
+/**
+ * Implements hook_disable().
+ */
+function loop_post_wysiwyg_disable() {
+  secure_permissions_rebuild();
+}
+
+/**
+ * Implements hook_secure_permissions.
+ *
+ * Allows authenticated users to use the text format "editor", so that they
+ * can use the WYSIWYG editor.
+ *
+ * @param $role
+ *   The role for which the permissions are being requested.
+ *
+ * @return
+ *   An array defining all the permissions for the site.
+ */
+function loop_post_wysiwyg_secure_permissions($role) {
+  $permissions = array('authenticated user' => 'use text format editor');
+  if (isset($permissions[$role])) {
+    return $permissions[$role];
+  }
+}


### PR DESCRIPTION
This pull request gives users access to use the text format 'editor', so they can use the WYSIWYG editor on posts/comments when the module loop_post_wysiwyg is enabled.
