### PR TITLE
Small changes to makefiles

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -16,5 +16,5 @@ projects[drupal][patch][] = "https://www.drupal.org/files/issues/optimize_scan-2
 ; Install profile.
 projects[loopdk][type] = "profile"
 projects[loopdk][download][type] = "git"
-projects[loopdk][download][url] = "git@github.com:os2loop/profile.git"
+projects[loopdk][download][url] = "https://github.com/os2loop/profile.git"
 projects[loopdk][download][branch] = "master"

--- a/loopdk.make
+++ b/loopdk.make
@@ -175,6 +175,7 @@ projects[saml_sp][download][branch] = "7.x-2.x"
 ; SAML SP bugfixes:
 projects[saml_sp][patch][] = "https://www.drupal.org/files/issues/nameid-correction.patch"
 projects[saml_sp][patch][] = "https://www.drupal.org/files/issues/2649478-saml_sp-validation_of_signed_elements_fails-2.patch"
+projects[saml_sp][patch][] = "https://www.drupal.org/files/issues/saml_sp_fix_make.patch"
 ; Custom SAML SP hooks
 projects[saml_sp][patch][] = "https://raw.githubusercontent.com/os2loop/profile/master/patches/saml_sp_drupal_login-alter_user_hooks.patch"
 


### PR DESCRIPTION
I changed the drupal.make file to use https instead of ssh when downloading the profile repo and added a patch to fix the saml_sp makefile, which makes the onelogin/php-saml download succeed.

These changes make it possible to install the drupal profile without an ssh key.

If the changes should go in another branch (master?), I will gladly create another pr or move the commits to my master.
