### PR TITLE
Fixed url of xmlseclibs

### DIFF
--- a/loopdk.make
+++ b/loopdk.make
@@ -270,6 +270,7 @@ libraries[php-saml][directory_name] = "php-saml"
 libraries[php-saml][destination] = "libraries"
 
 libraries[xmlseclibs][download][type] = "git"
-libraries[xmlseclibs][download][url] = "https://github.com/Maks3w/xmlseclibs.git"
+libraries[xmlseclibs][download][url] = "https://github.com/robrichards/xmlseclibs.git"
+libraries[xmlseclibs][download][branch] = "1.3.2"
 libraries[xmlseclibs][directory_name] = "xmlseclibs"
 libraries[xmlseclibs][destination] = "libraries"


### PR DESCRIPTION
https://github.com/Maks3w/xmlseclibs.git has gone away, but the changes we're merged into https://github.com/robrichards/xmlseclibs/tree/1.3.2.
