### PR TITLE
Users should not be able to self-register on sites using saml-login

### DIFF
--- a/modules/loop_saml/loop_saml.module
+++ b/modules/loop_saml/loop_saml.module
@@ -160,3 +160,19 @@ function _loop_saml_setup_account($account, array $attributes) {
 function loop_saml_preprocess(&$variables) {
   $variables['logged_in_via_saml'] = saml_sp_drupal_login_is_authenticated();
 }
+
+/**
+ * Implements hook_menu_alter().
+ *
+ * Hack to prevent user from accessing the external user registration page.
+ */
+function loop_saml_menu_alter(&$items) {
+  $items['user/register']['page callback'] = 'loop_saml_user_register_page_callback';
+}
+
+/**
+ * Prevent access to the external user registration page.
+ */
+function loop_saml_user_register_page_callback() {
+  drupal_goto('user');
+}

--- a/modules/loop_user/loop_user.features.fe_block_settings.inc
+++ b/modules/loop_user/loop_user.features.fe_block_settings.inc
@@ -18,7 +18,7 @@ function loop_user_default_fe_block_settings() {
     'delta' => 'login',
     'module' => 'user',
     'node_types' => array(),
-    'pages' => 'loop_saml_redirect',
+    'pages' => 'loop_saml_redirect' . PHP_EOL . 'page-not-found',
     'roles' => array(),
     'themes' => array(
       'bartik' => array(

--- a/modules/loop_user/loop_user.install
+++ b/modules/loop_user/loop_user.install
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Handles updates.
+ */
+
+/**
+ * Set the pages on which the login block should not be visible.
+ */
+function loop_user_update_7001() {
+  _block_rehash('loop');
+
+  db_merge('block')
+    ->key(array(
+      'delta' => 'login',
+      'module' => 'user',
+    ))
+    ->fields(array(
+      'pages' => 'loop_saml_redirect' . PHP_EOL . 'page-not-found',
+    ))
+    ->execute();
+}


### PR DESCRIPTION
In order to make saml login work, we need to allow creation of users on the site. However, users should not be allowed to create accounts manually, but only indirectly by using saml login. 
