### PR TITLE
Updates to Flare parser

### DIFF
--- a/modules/loop_external_data/loop_external_data.module
+++ b/modules/loop_external_data/loop_external_data.module
@@ -279,19 +279,28 @@ function _loop_external_data_build_dropdown($item) {
 
   switch ($item->type) {
     case 'index':
-      $trees = $wrapper->field_tree->value();
+      $children = $wrapper->field_tree->value();
       $items['index_title'] = $item->title;
-      foreach ($trees as $tree) {
-        $items['childs'][] = _loop_external_data_build_dropdown($tree);
-        $items['#theme'] = 'loop_external_data_dropdown_trees';
+      foreach ($children as $child) {
+        if ($child->type == 'tree') {
+          $items['childs'][] = _loop_external_data_build_dropdown($child);
+          $items['#theme'] = 'loop_external_data_dropdown_trees';
+        }
+        else {
+          $new_child['#theme'] = 'loop_external_data_dropdown_leaf';
+          $new_child['#title'] = $child->title;
+          $new_child['#nid'] = $child->nid;
+          $items['childs'][] = $new_child;
+          $items['#theme'] = 'loop_external_data_dropdown_trees';
+        }
       }
       break;
 
     case 'tree':
       $items['#title'] = $item->title;
       $items['#nid'] = $item->nid;
-      $leafs = $wrapper->field_leaf->value();
-      foreach ($leafs as $child) {
+      $children = $wrapper->field_leaf->value();
+      foreach ($children as $child) {
         if ($child->type == 'tree') {
           $items['#childs'][] = _loop_external_data_build_dropdown($child);
           $items['#theme'] = 'loop_external_data_dropdown_trees';
@@ -388,18 +397,29 @@ function _loop_external_data_build_tree($item) {
 
   switch ($item->type) {
     case 'index':
-      $trees = $wrapper->field_tree->value();
-      foreach ($trees as $tree) {
-        $items['#childs'][] = _loop_external_data_build_tree($tree);
-        $items['#theme'] = 'loop_external_data_trees';
+      $children = $wrapper->field_tree->value();
+      foreach ($children as $child) {
+        if ($child->type == 'tree') {
+          $items['#childs'][] = _loop_external_data_build_tree($child);
+          $items['#theme'] = 'loop_external_data_trees';
+        }
+        else {
+          $new_child['#theme'] = 'loop_external_data_leaf';
+          $new_child['#title'] = $child->title;
+          $display = array('label' => 'hidden');
+          $new_child['#body'] = field_view_field('node', $child, 'body', $display);
+          $new_child['#nid'] = $child->nid;
+          $items['#childs'][] = $new_child;
+          $items['#theme'] = 'loop_external_data_trees';
+        }
       }
       break;
 
     case 'tree':
       $items['#title'] = $item->title;
       $items['#nid'] = $item->nid;
-      $leafs = $wrapper->field_leaf->value();
-      foreach ($leafs as $child) {
+      $children = $wrapper->field_leaf->value();
+      foreach ($children as $child) {
         if ($child->type == 'tree') {
           $items['#childs'][] = _loop_external_data_build_tree($child);
           $items['#theme'] = 'loop_external_data_trees';

--- a/modules/loop_external_data/loop_external_data.module
+++ b/modules/loop_external_data/loop_external_data.module
@@ -330,7 +330,7 @@ function _loop_external_data_build_dropdown($item) {
  */
 function _loop_external_data_find_index($item) {
   // Find index.
-  if ($item->type != 'index' && $item->type !== 'post') {
+  if ($item && $item->type != 'index' && $item->type !== 'post') {
     $tree = db_select('field_data_field_leaf', 'l')
       ->fields('l', array('entity_id'))
       ->condition('field_leaf_target_id', $item->nid)

--- a/modules/loop_external_data/loop_external_data.module
+++ b/modules/loop_external_data/loop_external_data.module
@@ -638,8 +638,9 @@ function _loop_external_data_fix_references_leaf($loop_leaf, $references) {
   foreach ($as as $a) {
     $href = $a->getAttribute('href');
 
-    $ref = $references[$href];
-    if (isset($ref)) {
+    // The href may be external and therefore not be in (internal) references.
+    if (isset($references[$href])) {
+      $ref = $references[$href];
       $new_path = '/node/' . $ref['nid'];
 
       $a->setAttribute('href', $new_path);

--- a/modules/loop_external_data/parsers/DITAParser.php
+++ b/modules/loop_external_data/parsers/DITAParser.php
@@ -221,13 +221,25 @@ class DITAParser implements ParserInterface {
       foreach ($xpath->query('//xref') as $xref) {
         // External links have the scope attribute set to external.
         $scope = $xref->getAttribute('scope');
+        // Not all external links have scope="external".
+        if (preg_match('@^([a-z]+:/)?/@', $xref->getAttribute('href'))) {
+          $scope = 'external';
+        }
 
         if ($scope != 'external') {
           $xhref = dirname($href) . '/' . $xref->getAttribute('href');
-          $next_index = count($xref_references);
 
           $xhref = explode('#', $xhref);
-          $xref_references[$this->collapsePath($xhref[0])] = $next_index;
+
+          // Check if we have seen this internal reference before.
+          // If not, add it to the internal references list.
+          $path = $this->collapsePath($xhref[0]);
+          if (isset($xref_references[$path])) {
+            $next_index = $xref_references[$path];
+          } else {
+            $next_index = count($xref_references);
+            $xref_references[$path] = $next_index;
+          }
 
           // Check for empty content, insert title from references topic as text.
           if ($xref->nodeValue === '') {

--- a/modules/loop_external_data/parsers/DITAParser.php
+++ b/modules/loop_external_data/parsers/DITAParser.php
@@ -394,7 +394,7 @@ class DITAParser implements ParserInterface {
     // Process each child and add to Index as children.
     foreach ($xml->children() as $child) {
       $node_type = $child->getName();
-      if ($node_type == 'topichead') {
+      if ($node_type == 'topichead' || $node_type == 'topicref') {
         $children[] = $this->traverseNode($child, $path_to_directory, $index_node_id, $object_references, $xref_references);
       }
     }

--- a/modules/loop_external_data/parsers/DITAParser.php
+++ b/modules/loop_external_data/parsers/DITAParser.php
@@ -124,6 +124,14 @@ class DITAParser implements ParserInterface {
       // Get the reference to the topicref file.
       $href = $node['href'];
 
+      // Strip any fragment identifier
+      $href = preg_replace('@#.*$@', '', $href);
+
+      $file_path = $path_to_directory . '/' . $href;
+      if (!file_exists($file_path)) {
+        return NULL;
+      }
+
       // Load body of topic into DOM.
       $body = simplexml_load_file($path_to_directory . '/' . $href)->body;
       $domnode = dom_import_simplexml($body[0]);


### PR DESCRIPTION
The current Flare parser assumes that content (`<topicref href="…"/>`) is always grouped under headers (`<topichead …/>`), but this is not always the case. Sometimes content is placed at the top-level in the table of contents.

This update handles topicref elements at top-level of the table of contents. 
