### PR TITLE
Fixed Flare parser to handle topicref nodes at top-level in DITA map

### DIFF
--- a/modules/loop_external_data/loop_external_data.module
+++ b/modules/loop_external_data/loop_external_data.module
@@ -279,19 +279,28 @@ function _loop_external_data_build_dropdown($item) {
 
   switch ($item->type) {
     case 'index':
-      $trees = $wrapper->field_tree->value();
+      $children = $wrapper->field_tree->value();
       $items['index_title'] = $item->title;
-      foreach ($trees as $tree) {
-        $items['childs'][] = _loop_external_data_build_dropdown($tree);
-        $items['#theme'] = 'loop_external_data_dropdown_trees';
+      foreach ($children as $child) {
+        if ($child->type == 'tree') {
+          $items['childs'][] = _loop_external_data_build_dropdown($child);
+          $items['#theme'] = 'loop_external_data_dropdown_trees';
+        }
+        else {
+          $new_child['#theme'] = 'loop_external_data_dropdown_leaf';
+          $new_child['#title'] = $child->title;
+          $new_child['#nid'] = $child->nid;
+          $items['childs'][] = $new_child;
+          $items['#theme'] = 'loop_external_data_dropdown_trees';
+        }
       }
       break;
 
     case 'tree':
       $items['#title'] = $item->title;
       $items['#nid'] = $item->nid;
-      $leafs = $wrapper->field_leaf->value();
-      foreach ($leafs as $child) {
+      $children = $wrapper->field_leaf->value();
+      foreach ($children as $child) {
         if ($child->type == 'tree') {
           $items['#childs'][] = _loop_external_data_build_dropdown($child);
           $items['#theme'] = 'loop_external_data_dropdown_trees';
@@ -321,7 +330,7 @@ function _loop_external_data_build_dropdown($item) {
  */
 function _loop_external_data_find_index($item) {
   // Find index.
-  if ($item->type != 'index' && $item->type !== 'post') {
+  if ($item && $item->type != 'index' && $item->type !== 'post') {
     $tree = db_select('field_data_field_leaf', 'l')
       ->fields('l', array('entity_id'))
       ->condition('field_leaf_target_id', $item->nid)
@@ -388,18 +397,29 @@ function _loop_external_data_build_tree($item) {
 
   switch ($item->type) {
     case 'index':
-      $trees = $wrapper->field_tree->value();
-      foreach ($trees as $tree) {
-        $items['#childs'][] = _loop_external_data_build_tree($tree);
-        $items['#theme'] = 'loop_external_data_trees';
+      $children = $wrapper->field_tree->value();
+      foreach ($children as $child) {
+        if ($child->type == 'tree') {
+          $items['#childs'][] = _loop_external_data_build_tree($child);
+          $items['#theme'] = 'loop_external_data_trees';
+        }
+        else {
+          $new_child['#theme'] = 'loop_external_data_leaf';
+          $new_child['#title'] = $child->title;
+          $display = array('label' => 'hidden');
+          $new_child['#body'] = field_view_field('node', $child, 'body', $display);
+          $new_child['#nid'] = $child->nid;
+          $items['#childs'][] = $new_child;
+          $items['#theme'] = 'loop_external_data_trees';
+        }
       }
       break;
 
     case 'tree':
       $items['#title'] = $item->title;
       $items['#nid'] = $item->nid;
-      $leafs = $wrapper->field_leaf->value();
-      foreach ($leafs as $child) {
+      $children = $wrapper->field_leaf->value();
+      foreach ($children as $child) {
         if ($child->type == 'tree') {
           $items['#childs'][] = _loop_external_data_build_tree($child);
           $items['#theme'] = 'loop_external_data_trees';
@@ -638,8 +658,9 @@ function _loop_external_data_fix_references_leaf($loop_leaf, $references) {
   foreach ($as as $a) {
     $href = $a->getAttribute('href');
 
-    $ref = $references[$href];
-    if (isset($ref)) {
+    // The href may be external and therefore not be in (internal) references.
+    if (isset($references[$href])) {
+      $ref = $references[$href];
       $new_path = '/node/' . $ref['nid'];
 
       $a->setAttribute('href', $new_path);


### PR DESCRIPTION
The current Flare parser assumes that content (<topicref href="…"/>) is always grouped under headers (<topichead …/>), but this is not always the case. Sometimes content is placed at the top-level in the DITA map (table of contents).

This update handles topicref elements at top-level of the DITA map.
