### PR TITLE
LOOP-465: Fixed check for non "administrator" access to admin paths

### DIFF
--- a/modules/loop_permissions/loop_permissions.module
+++ b/modules/loop_permissions/loop_permissions.module
@@ -67,9 +67,9 @@ function loop_permissions_menu_access() {
     return FALSE;
   }
 
-  // Check admin access for 'document author' and 'document collection editor'.
+  // Non "administrator" users must have explicit access to admin paths.
   $user_role_names = array_values($GLOBALS['user']->roles);
-  if (array_intersect($user_role_names, array('document author', 'document collection editor', 'external sources editor'))) {
+  if (!array_intersect($user_role_names, array('administrator'))) {
     if (!user_access('access path ' . $path)) {
       return FALSE;
     }


### PR DESCRIPTION
This fixes an issue with users being both "administrator" and "document collection editor" (or "document author" or "external sources editor") loosing access to all admin menu items.