### PR TITLE
Ret branch navne til at referere til korrekte branches

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -8,7 +8,7 @@ projects[drupal][type] = core
 projects[drupal][version] = 7.73
 projects[drupal][patch][] = "https://drupal.org/files/drupal-menu_navigation_links-1018614-83.patch"
 projects[drupal][patch][] = "https://drupal.org/files/issues/translate_role_names-2205581-1.patch"
-projects[drupal][patch][] = "https://raw.githubusercontent.com/os2loop/profile/master/patches/rebuild_local_js_alter.patch"
+projects[drupal][patch][] = "https://raw.githubusercontent.com/os2loop/profile/main/patches/rebuild_local_js_alter.patch"
 
 ; Install profile.
 projects[loopdk][type] = "profile"

--- a/loopdk.make
+++ b/loopdk.make
@@ -192,8 +192,8 @@ projects[rules][version] = "2.12"
 projects[saml_sp][subdir] = "contrib"
 projects[saml_sp][version] = "2.2"
 ; Custom SAML SP hooks
-projects[saml_sp][patch][] = "https://raw.githubusercontent.com/os2loop/profile/master/patches/saml_sp_drupal_login-alter_user_hooks.patch"
-projects[saml_sp][patch][] = "https://raw.githubusercontent.com/os2loop/profile/master/patches/saml_sp_remove_make_file.patch"
+projects[saml_sp][patch][] = "https://raw.githubusercontent.com/os2loop/profile/main/patches/saml_sp_drupal_login-alter_user_hooks.patch"
+projects[saml_sp][patch][] = "https://raw.githubusercontent.com/os2loop/profile/main/patches/saml_sp_remove_make_file.patch"
 
 projects[search_api][subdir] = "contrib"
 projects[search_api][version] = "1.26"
@@ -268,7 +268,7 @@ projects[transliteration][version] = "3.2"
 
 projects[user_import][subdir] = "contrib"
 projects[user_import][version] = "3.x-dev"
-projects[user_import][patch][] = "https://raw.githubusercontent.com/os2loop/profile/release/patches/user_import-_user_import_publication_email.patch"
+projects[user_import][patch][] = "https://raw.githubusercontent.com/os2loop/profile/main/patches/user_import-_user_import_publication_email.patch"
 
 projects[uuid][subdir] = "contrib"
 projects[uuid][version] = "1.3"


### PR DESCRIPTION
Ifølge readme skulle man fint kunne køre make filerne, disse fejler dog da der forsøges at hentes patches fra hhv. `master` og `release` branches, hvoraf ingen af dem findes.

Dette pull request retter dem til at hente fra `main` branchen, som er det indtryk jeg har er den som der skal hentes fra.